### PR TITLE
Rename ContactId parameter to Id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Get-WikeFolderHistory
 - New-WrikeFieldFilter
 
+### Changed
+- Breaking change - changed the ContactId parameter to Id on Get-WrikeContact and Get-WrikeContactHistory. Would have added ContactId back as an alias were there more users, but since maybe nobody is using this module yet, I decided against it.
+
 ## [0.1.1] - 2021-09-22
 ### Added
 - New Get-WrikeContactHistory function.

--- a/WrikeExplorer/Public/Get-WrikeContact.ps1
+++ b/WrikeExplorer/Public/Get-WrikeContact.ps1
@@ -2,12 +2,12 @@ function Get-WrikeContact {
     [CmdletBinding()]
     [OutputType([WrikeContact])]
     param (
-        # Specifies one or more optional ContactId values for known contacts
+        # Specifies one or more optional ID values for known contacts
         [Parameter(ValueFromPipelineByPropertyName)]
+        [ValidateCount(0, 100)]
         [ValidateNotNullOrEmpty()]
-        [Alias('Id')]
         [string[]]
-        $ContactId,
+        $Id,
 
         # Specifies that the Wrike Contact record for the current user should be returned
         [Parameter()]
@@ -28,10 +28,6 @@ function Get-WrikeContact {
     )
 
     process {
-        if ($ContactId.Count -gt 100) {
-            Write-Error 'The Wrike API imposes a limit of 100 contact IDs in a contact history query.'
-            return
-        }
         $query = @{}
         if ($MyInvocation.BoundParameters.ContainsKey('Me')) {
             $query.me = $Me.ToString().ToLower()
@@ -49,8 +45,8 @@ function Get-WrikeContact {
             $query.fields = $json
         }
         $path = "contacts"
-        if ($null -ne $ContactId -and $ContactId.Count -gt 0) {
-            $path += '/' + [string]::Join(',', $ContactId)
+        if ($null -ne $Id -and $Id.Count -gt 0) {
+            $path += '/' + [string]::Join(',', $Id)
         }
         Invoke-WrikeApi -Path $path -ResponseType contacts -Query $query
     }

--- a/WrikeExplorer/Public/Get-WrikeContactHistory.ps1
+++ b/WrikeExplorer/Public/Get-WrikeContactHistory.ps1
@@ -2,12 +2,12 @@ function Get-WrikeContactHistory {
     [CmdletBinding()]
     [OutputType([WrikeContactHistory])]
     param (
-        # Specifies one or more optional ContactId values for known contacts
+        # Specifies one or more ID values for known contacts
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [ValidateCount(1, 100)]
         [ValidateNotNullOrEmpty()]
-        [Alias('Id')]
         [string[]]
-        $ContactId,
+        $Id,
 
         # Specifies the inclusive start of the time range for the contact history request
         [Parameter()]
@@ -31,10 +31,6 @@ function Get-WrikeContactHistory {
             Write-Error 'UpdatedBefore cannot be less than or equal to UpdatedAfter.'
             return
         }
-        if ($ContactId.Count -gt 100) {
-            Write-Error 'The Wrike API imposes a limit of 100 contact IDs in a contact history query.'
-            return
-        }
 
         $query = @{}
         if ($MyInvocation.BoundParameters.ContainsKey('Include')) {
@@ -52,8 +48,8 @@ function Get-WrikeContactHistory {
         }
 
         $path = 'contacts'
-        if ($null -ne $ContactId -and $ContactId.Count -gt 0) {
-            $path += '/' + [string]::Join(',', $ContactId)
+        if ($null -ne $Id -and $Id.Count -gt 0) {
+            $path += '/' + [string]::Join(',', $Id)
         }
         $path += '/contacts_history'
         Invoke-WrikeApi -Path $path -ResponseType contactsHistory -Query $query

--- a/docs/en-US/Get-WrikeContact.md
+++ b/docs/en-US/Get-WrikeContact.md
@@ -13,7 +13,7 @@ Get one or more contact records from the Wrike API
 ## SYNTAX
 
 ```
-Get-WrikeContact [[-ContactId] <String[]>] [-Me] [-Deleted] [[-Include] <String[]>] [<CommonParameters>]
+Get-WrikeContact [[-Id] <String[]>] [-Me] [-Deleted] [[-Include] <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -51,27 +51,12 @@ Get the Wrike contact record representing the current Wrike user.
 
 ### Example 5
 ```powershell
-PS C:\> Get-WrikeContact -ContactId ABC123, ZXY789
+PS C:\> Get-WrikeContact -Id ABC123, ZXY789
 ```
 
 Gets the Wrike contact records for two specific contacts based on their contact IDs.
 
 ## PARAMETERS
-
-### -ContactId
-Specifies one or more Wrike contact IDs to be returned from the Wrike contacts API. Limit of 100 per invocation.
-
-```yaml
-Type: String[]
-Parameter Sets: (All)
-Aliases: Id
-
-Required: False
-Position: 0
-Default value: None
-Accept pipeline input: True (ByPropertyName)
-Accept wildcard characters: False
-```
 
 ### -Deleted
 Specifies whether to limit the results either to deleted, or not-deleted users.
@@ -85,6 +70,21 @@ Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+Specifies one or more optional ID values for known contacts
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 

--- a/docs/en-US/Get-WrikeContactHistory.md
+++ b/docs/en-US/Get-WrikeContactHistory.md
@@ -13,7 +13,7 @@ Gets one or more contact history records from the Wrike API
 ## SYNTAX
 
 ```
-Get-WrikeContactHistory [-ContactId] <String[]> [[-UpdatedAfter] <DateTime>] [[-UpdatedBefore] <DateTime>]
+Get-WrikeContactHistory [-Id] <String[]> [[-UpdatedAfter] <DateTime>] [[-UpdatedBefore] <DateTime>]
  [[-Include] <String[]>] [<CommonParameters>]
 ```
 
@@ -31,13 +31,13 @@ Gets the contact record representing the user associated with the current perman
 
 ## PARAMETERS
 
-### -ContactId
-Specifies one or more Wrike contact IDs to be returned from the Wrike contacts API. Limit of 100 per invocation.
+### -Id
+Specifies one or more ID values for known contacts
 
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases: Id
+Aliases:
 
 Required: True
 Position: 0

--- a/docs/en-US/Get-WrikeFolderHistory.md
+++ b/docs/en-US/Get-WrikeFolderHistory.md
@@ -106,4 +106,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
 [Wrike API Folders & Projects docs](https://developers.wrike.com/api/v4/folders-projects/)

--- a/tests/out/testResults.xml
+++ b/tests/out/testResults.xml
@@ -1,189 +1,189 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<test-results xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="nunit_schema_2.5.xsd" name="Pester" total="76" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="2" invalid="0" date="2021-09-23" time="15:38:39">
-  <environment platform="Microsoft Windows 10 Enterprise|C:\WINDOWS|\Device\Harddisk0\Partition3" clr-version="Unknown" os-version="10.0.19042" cwd="C:\Users\jh\source\repos\WrikeExplorer\tests" nunit-version="2.5.8.0" user-domain="MILESTONE" machine-name="USLT-JH-02" user="jh" />
+<test-results xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="nunit_schema_2.5.xsd" name="Pester" total="76" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="2" invalid="0" date="2021-09-24" time="08:53:55">
+  <environment user-domain="MILESTONE" cwd="C:\Users\jh\source\repos\WrikeExplorer\tests" user="jh" clr-version="Unknown" os-version="10.0.19042" machine-name="USLT-JH-02" platform="Microsoft Windows 10 Enterprise|C:\WINDOWS|\Device\Harddisk0\Partition3" nunit-version="2.5.8.0" />
   <culture-info current-culture="en-US" current-uiculture="en-US" />
-  <test-suite type="TestFixture" name="Pester" executed="True" result="Ignored" success="True" time="2.115" asserts="0" description="Pester">
+  <test-suite type="TestFixture" name="Pester" executed="True" result="Ignored" success="True" time="4.6526" asserts="0" description="Pester">
     <results>
-      <test-suite type="TestFixture" name="C:\Users\jh\source\repos\WrikeExplorer\tests\Help.tests.ps1" executed="True" result="Success" success="True" time="1.0016" asserts="0" description="C:\Users\jh\source\repos\WrikeExplorer\tests\Help.tests.ps1">
+      <test-suite type="TestFixture" name="C:\Users\jh\source\repos\WrikeExplorer\tests\Help.tests.ps1" executed="True" result="Success" success="True" time="2.7509" asserts="0" description="C:\Users\jh\source\repos\WrikeExplorer\tests\Help.tests.ps1">
         <results>
-          <test-suite type="TestFixture" name="Test help for Clear-WrikeAccessToken" executed="True" result="Success" success="True" time="0.0791" asserts="0" description="Test help for Clear-WrikeAccessToken">
+          <test-suite type="TestFixture" name="Test help for Clear-WrikeAccessToken" executed="True" result="Success" success="True" time="0.5731" asserts="0" description="Test help for Clear-WrikeAccessToken">
             <results>
-              <test-case description="Help is not auto-generated" name="Test help for Clear-WrikeAccessToken.Help is not auto-generated" time="0.0108" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has description" name="Test help for Clear-WrikeAccessToken.Has description" time="0.0052" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example code" name="Test help for Clear-WrikeAccessToken.Has example code" time="0.0066" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example help" name="Test help for Clear-WrikeAccessToken.Has example help" time="0.0106" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Help is not auto-generated" name="Test help for Clear-WrikeAccessToken.Help is not auto-generated" time="0.3025" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has description" name="Test help for Clear-WrikeAccessToken.Has description" time="0.0343" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example code" name="Test help for Clear-WrikeAccessToken.Has example code" time="0.0241" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example help" name="Test help for Clear-WrikeAccessToken.Has example help" time="0.0247" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
-          <test-suite type="TestFixture" name="Test help for Get-WrikeApiVersion" executed="True" result="Success" success="True" time="0.131" asserts="0" description="Test help for Get-WrikeApiVersion">
+          <test-suite type="TestFixture" name="Test help for Get-WrikeApiVersion" executed="True" result="Success" success="True" time="0.6447" asserts="0" description="Test help for Get-WrikeApiVersion">
             <results>
-              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeApiVersion.Help is not auto-generated" time="0.0073" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has description" name="Test help for Get-WrikeApiVersion.Has description" time="0.0042" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example code" name="Test help for Get-WrikeApiVersion.Has example code" time="0.0051" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example help" name="Test help for Get-WrikeApiVersion.Has example help" time="0.0048" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeApiVersion.Help is not auto-generated" time="0.008" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has description" name="Test help for Get-WrikeApiVersion.Has description" time="0.0096" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example code" name="Test help for Get-WrikeApiVersion.Has example code" time="0.0082" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example help" name="Test help for Get-WrikeApiVersion.Has example help" time="0.0065" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
-          <test-suite type="TestFixture" name="Test help for Get-WrikeContact" executed="True" result="Success" success="True" time="0.1868" asserts="0" description="Test help for Get-WrikeContact">
+          <test-suite type="TestFixture" name="Test help for Get-WrikeContact" executed="True" result="Success" success="True" time="0.7553" asserts="0" description="Test help for Get-WrikeContact">
             <results>
-              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeContact.Help is not auto-generated" time="0.0077" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has description" name="Test help for Get-WrikeContact.Has description" time="0.0055" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example code" name="Test help for Get-WrikeContact.Has example code" time="0.0045" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example help" name="Test help for Get-WrikeContact.Has example help" time="0.0054" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeContact.Help is not auto-generated" time="0.0218" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has description" name="Test help for Get-WrikeContact.Has description" time="0.0078" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example code" name="Test help for Get-WrikeContact.Has example code" time="0.0148" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example help" name="Test help for Get-WrikeContact.Has example help" time="0.0202" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
-          <test-suite type="TestFixture" name="Test help for Get-WrikeContactHistory" executed="True" result="Success" success="True" time="0.2367" asserts="0" description="Test help for Get-WrikeContactHistory">
+          <test-suite type="TestFixture" name="Test help for Get-WrikeContactHistory" executed="True" result="Success" success="True" time="0.8416" asserts="0" description="Test help for Get-WrikeContactHistory">
             <results>
-              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeContactHistory.Help is not auto-generated" time="0.0077" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has description" name="Test help for Get-WrikeContactHistory.Has description" time="0.0118" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example code" name="Test help for Get-WrikeContactHistory.Has example code" time="0.004" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example help" name="Test help for Get-WrikeContactHistory.Has example help" time="0.0047" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeContactHistory.Help is not auto-generated" time="0.0111" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has description" name="Test help for Get-WrikeContactHistory.Has description" time="0.0108" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example code" name="Test help for Get-WrikeContactHistory.Has example code" time="0.0086" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example help" name="Test help for Get-WrikeContactHistory.Has example help" time="0.0117" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
-          <test-suite type="TestFixture" name="Test help for Get-WrikeCustomField" executed="True" result="Success" success="True" time="0.2912" asserts="0" description="Test help for Get-WrikeCustomField">
+          <test-suite type="TestFixture" name="Test help for Get-WrikeCustomField" executed="True" result="Success" success="True" time="0.9166" asserts="0" description="Test help for Get-WrikeCustomField">
             <results>
-              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeCustomField.Help is not auto-generated" time="0.0079" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has description" name="Test help for Get-WrikeCustomField.Has description" time="0.0046" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example code" name="Test help for Get-WrikeCustomField.Has example code" time="0.0049" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example help" name="Test help for Get-WrikeCustomField.Has example help" time="0.0055" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeCustomField.Help is not auto-generated" time="0.0068" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has description" name="Test help for Get-WrikeCustomField.Has description" time="0.0075" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example code" name="Test help for Get-WrikeCustomField.Has example code" time="0.0149" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example help" name="Test help for Get-WrikeCustomField.Has example help" time="0.0054" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
-          <test-suite type="TestFixture" name="Test help for Get-WrikeDataExport" executed="True" result="Success" success="True" time="0.3428" asserts="0" description="Test help for Get-WrikeDataExport">
+          <test-suite type="TestFixture" name="Test help for Get-WrikeDataExport" executed="True" result="Success" success="True" time="0.9835" asserts="0" description="Test help for Get-WrikeDataExport">
             <results>
-              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeDataExport.Help is not auto-generated" time="0.0131" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has description" name="Test help for Get-WrikeDataExport.Has description" time="0.0042" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example code" name="Test help for Get-WrikeDataExport.Has example code" time="0.0053" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example help" name="Test help for Get-WrikeDataExport.Has example help" time="0.0052" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeDataExport.Help is not auto-generated" time="0.0082" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has description" name="Test help for Get-WrikeDataExport.Has description" time="0.0077" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example code" name="Test help for Get-WrikeDataExport.Has example code" time="0.008" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example help" name="Test help for Get-WrikeDataExport.Has example help" time="0.0082" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
-          <test-suite type="TestFixture" name="Test help for Get-WrikeDataExportSchema" executed="True" result="Success" success="True" time="0.389" asserts="0" description="Test help for Get-WrikeDataExportSchema">
+          <test-suite type="TestFixture" name="Test help for Get-WrikeDataExportSchema" executed="True" result="Success" success="True" time="1.0496" asserts="0" description="Test help for Get-WrikeDataExportSchema">
             <results>
-              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeDataExportSchema.Help is not auto-generated" time="0.0078" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has description" name="Test help for Get-WrikeDataExportSchema.Has description" time="0.0048" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example code" name="Test help for Get-WrikeDataExportSchema.Has example code" time="0.0042" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example help" name="Test help for Get-WrikeDataExportSchema.Has example help" time="0.0076" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeDataExportSchema.Help is not auto-generated" time="0.0113" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has description" name="Test help for Get-WrikeDataExportSchema.Has description" time="0.0093" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example code" name="Test help for Get-WrikeDataExportSchema.Has example code" time="0.0058" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example help" name="Test help for Get-WrikeDataExportSchema.Has example help" time="0.006" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
-          <test-suite type="TestFixture" name="Test help for Get-WrikeExplorerConfig" executed="True" result="Success" success="True" time="0.4301" asserts="0" description="Test help for Get-WrikeExplorerConfig">
+          <test-suite type="TestFixture" name="Test help for Get-WrikeExplorerConfig" executed="True" result="Success" success="True" time="1.1114" asserts="0" description="Test help for Get-WrikeExplorerConfig">
             <results>
-              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeExplorerConfig.Help is not auto-generated" time="0.008" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has description" name="Test help for Get-WrikeExplorerConfig.Has description" time="0.0034" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example code" name="Test help for Get-WrikeExplorerConfig.Has example code" time="0.0059" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example help" name="Test help for Get-WrikeExplorerConfig.Has example help" time="0.0045" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeExplorerConfig.Help is not auto-generated" time="0.0116" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has description" name="Test help for Get-WrikeExplorerConfig.Has description" time="0.005" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example code" name="Test help for Get-WrikeExplorerConfig.Has example code" time="0.0051" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example help" name="Test help for Get-WrikeExplorerConfig.Has example help" time="0.0051" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
-          <test-suite type="TestFixture" name="Test help for Get-WrikeFolder" executed="True" result="Success" success="True" time="0.4803" asserts="0" description="Test help for Get-WrikeFolder">
+          <test-suite type="TestFixture" name="Test help for Get-WrikeFolder" executed="True" result="Success" success="True" time="1.2655" asserts="0" description="Test help for Get-WrikeFolder">
             <results>
-              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeFolder.Help is not auto-generated" time="0.0054" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has description" name="Test help for Get-WrikeFolder.Has description" time="0.0039" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example code" name="Test help for Get-WrikeFolder.Has example code" time="0.0068" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example help" name="Test help for Get-WrikeFolder.Has example help" time="0.0074" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeFolder.Help is not auto-generated" time="0.0688" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has description" name="Test help for Get-WrikeFolder.Has description" time="0.0179" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example code" name="Test help for Get-WrikeFolder.Has example code" time="0.0235" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example help" name="Test help for Get-WrikeFolder.Has example help" time="0.0105" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
-          <test-suite type="TestFixture" name="Test help for Get-WrikeFolderHistory" executed="True" result="Success" success="True" time="0.5244" asserts="0" description="Test help for Get-WrikeFolderHistory">
+          <test-suite type="TestFixture" name="Test help for Get-WrikeFolderHistory" executed="True" result="Success" success="True" time="1.3613" asserts="0" description="Test help for Get-WrikeFolderHistory">
             <results>
-              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeFolderHistory.Help is not auto-generated" time="0.0053" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has description" name="Test help for Get-WrikeFolderHistory.Has description" time="0.0037" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example code" name="Test help for Get-WrikeFolderHistory.Has example code" time="0.0041" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example help" name="Test help for Get-WrikeFolderHistory.Has example help" time="0.0039" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Help is not auto-generated" name="Test help for Get-WrikeFolderHistory.Help is not auto-generated" time="0.0089" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has description" name="Test help for Get-WrikeFolderHistory.Has description" time="0.0096" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example code" name="Test help for Get-WrikeFolderHistory.Has example code" time="0.0125" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example help" name="Test help for Get-WrikeFolderHistory.Has example help" time="0.0078" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
-          <test-suite type="TestFixture" name="Test help for Invoke-WrikeApi" executed="True" result="Success" success="True" time="0.5734" asserts="0" description="Test help for Invoke-WrikeApi">
+          <test-suite type="TestFixture" name="Test help for Invoke-WrikeApi" executed="True" result="Success" success="True" time="1.4292" asserts="0" description="Test help for Invoke-WrikeApi">
             <results>
-              <test-case description="Help is not auto-generated" name="Test help for Invoke-WrikeApi.Help is not auto-generated" time="0.0066" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has description" name="Test help for Invoke-WrikeApi.Has description" time="0.0034" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example code" name="Test help for Invoke-WrikeApi.Has example code" time="0.0044" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example help" name="Test help for Invoke-WrikeApi.Has example help" time="0.0051" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Help is not auto-generated" name="Test help for Invoke-WrikeApi.Help is not auto-generated" time="0.0094" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has description" name="Test help for Invoke-WrikeApi.Has description" time="0.0148" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example code" name="Test help for Invoke-WrikeApi.Has example code" time="0.0088" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example help" name="Test help for Invoke-WrikeApi.Has example help" time="0.0089" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
-          <test-suite type="TestFixture" name="Test help for New-WrikeFieldFilter" executed="True" result="Success" success="True" time="0.6261" asserts="0" description="Test help for New-WrikeFieldFilter">
+          <test-suite type="TestFixture" name="Test help for New-WrikeFieldFilter" executed="True" result="Success" success="True" time="1.4906" asserts="0" description="Test help for New-WrikeFieldFilter">
             <results>
-              <test-case description="Help is not auto-generated" name="Test help for New-WrikeFieldFilter.Help is not auto-generated" time="0.0069" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has description" name="Test help for New-WrikeFieldFilter.Has description" time="0.0109" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example code" name="Test help for New-WrikeFieldFilter.Has example code" time="0.0055" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example help" name="Test help for New-WrikeFieldFilter.Has example help" time="0.0077" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Help is not auto-generated" name="Test help for New-WrikeFieldFilter.Help is not auto-generated" time="0.0067" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has description" name="Test help for New-WrikeFieldFilter.Has description" time="0.006" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example code" name="Test help for New-WrikeFieldFilter.Has example code" time="0.0049" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example help" name="Test help for New-WrikeFieldFilter.Has example help" time="0.0071" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
-          <test-suite type="TestFixture" name="Test help for Request-WrikeDataExport" executed="True" result="Success" success="True" time="0.6961" asserts="0" description="Test help for Request-WrikeDataExport">
+          <test-suite type="TestFixture" name="Test help for Request-WrikeDataExport" executed="True" result="Success" success="True" time="1.5721" asserts="0" description="Test help for Request-WrikeDataExport">
             <results>
-              <test-case description="Help is not auto-generated" name="Test help for Request-WrikeDataExport.Help is not auto-generated" time="0.0137" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has description" name="Test help for Request-WrikeDataExport.Has description" time="0.0055" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example code" name="Test help for Request-WrikeDataExport.Has example code" time="0.0072" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example help" name="Test help for Request-WrikeDataExport.Has example help" time="0.0059" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Help is not auto-generated" name="Test help for Request-WrikeDataExport.Help is not auto-generated" time="0.0157" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has description" name="Test help for Request-WrikeDataExport.Has description" time="0.0085" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example code" name="Test help for Request-WrikeDataExport.Has example code" time="0.0106" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example help" name="Test help for Request-WrikeDataExport.Has example help" time="0.0093" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
-          <test-suite type="TestFixture" name="Test help for Save-WrikeDataExport" executed="True" result="Success" success="True" time="0.7518" asserts="0" description="Test help for Save-WrikeDataExport">
+          <test-suite type="TestFixture" name="Test help for Save-WrikeDataExport" executed="True" result="Success" success="True" time="1.6306" asserts="0" description="Test help for Save-WrikeDataExport">
             <results>
-              <test-case description="Help is not auto-generated" name="Test help for Save-WrikeDataExport.Help is not auto-generated" time="0.0134" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has description" name="Test help for Save-WrikeDataExport.Has description" time="0.0058" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example code" name="Test help for Save-WrikeDataExport.Has example code" time="0.0055" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example help" name="Test help for Save-WrikeDataExport.Has example help" time="0.0047" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Help is not auto-generated" name="Test help for Save-WrikeDataExport.Help is not auto-generated" time="0.0074" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has description" name="Test help for Save-WrikeDataExport.Has description" time="0.0052" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example code" name="Test help for Save-WrikeDataExport.Has example code" time="0.0052" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example help" name="Test help for Save-WrikeDataExport.Has example help" time="0.0052" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
-          <test-suite type="TestFixture" name="Test help for Set-WrikeAccessToken" executed="True" result="Success" success="True" time="0.7938" asserts="0" description="Test help for Set-WrikeAccessToken">
+          <test-suite type="TestFixture" name="Test help for Set-WrikeAccessToken" executed="True" result="Success" success="True" time="1.6976" asserts="0" description="Test help for Set-WrikeAccessToken">
             <results>
-              <test-case description="Help is not auto-generated" name="Test help for Set-WrikeAccessToken.Help is not auto-generated" time="0.0051" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has description" name="Test help for Set-WrikeAccessToken.Has description" time="0.0034" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example code" name="Test help for Set-WrikeAccessToken.Has example code" time="0.0039" asserts="0" success="True" result="Success" executed="True" />
-              <test-case description="Has example help" name="Test help for Set-WrikeAccessToken.Has example help" time="0.0084" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Help is not auto-generated" name="Test help for Set-WrikeAccessToken.Help is not auto-generated" time="0.0092" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has description" name="Test help for Set-WrikeAccessToken.Has description" time="0.0063" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example code" name="Test help for Set-WrikeAccessToken.Has example code" time="0.0071" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Has example help" name="Test help for Set-WrikeAccessToken.Has example help" time="0.0058" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
         </results>
       </test-suite>
-      <test-suite type="TestFixture" name="C:\Users\jh\source\repos\WrikeExplorer\tests\Manifest.tests.ps1" executed="True" result="Ignored" success="True" time="0.327" asserts="0" description="C:\Users\jh\source\repos\WrikeExplorer\tests\Manifest.tests.ps1">
+      <test-suite type="TestFixture" name="C:\Users\jh\source\repos\WrikeExplorer\tests\Manifest.tests.ps1" executed="True" result="Ignored" success="True" time="0.6474" asserts="0" description="C:\Users\jh\source\repos\WrikeExplorer\tests\Manifest.tests.ps1">
         <results>
-          <test-suite type="TestFixture" name="Module manifest" executed="True" result="Success" success="True" time="0.0809" asserts="0" description="Module manifest">
+          <test-suite type="TestFixture" name="Module manifest" executed="True" result="Success" success="True" time="0.2429" asserts="0" description="Module manifest">
             <results>
-              <test-suite type="TestFixture" name="Module manifest.Validation" executed="True" result="Success" success="True" time="0.0727" asserts="0" description="Module manifest.Validation">
+              <test-suite type="TestFixture" name="Module manifest.Validation" executed="True" result="Success" success="True" time="0.2382" asserts="0" description="Module manifest.Validation">
                 <results>
-                  <test-case description="Has a valid manifest" name="Module manifest.Validation.Has a valid manifest" time="0.008" asserts="0" success="True" result="Success" executed="True" />
-                  <test-case description="Has a valid name in the manifest" name="Module manifest.Validation.Has a valid name in the manifest" time="0.006" asserts="0" success="True" result="Success" executed="True" />
-                  <test-case description="Has a valid root module" name="Module manifest.Validation.Has a valid root module" time="0.0052" asserts="0" success="True" result="Success" executed="True" />
-                  <test-case description="Has a valid version in the manifest" name="Module manifest.Validation.Has a valid version in the manifest" time="0.0052" asserts="0" success="True" result="Success" executed="True" />
-                  <test-case description="Has a valid description" name="Module manifest.Validation.Has a valid description" time="0.0057" asserts="0" success="True" result="Success" executed="True" />
-                  <test-case description="Has a valid author" name="Module manifest.Validation.Has a valid author" time="0.0102" asserts="0" success="True" result="Success" executed="True" />
-                  <test-case description="Has a valid guid" name="Module manifest.Validation.Has a valid guid" time="0.0061" asserts="0" success="True" result="Success" executed="True" />
-                  <test-case description="Has a valid copyright" name="Module manifest.Validation.Has a valid copyright" time="0.0062" asserts="0" success="True" result="Success" executed="True" />
-                  <test-case description="Has a valid version in the changelog" name="Module manifest.Validation.Has a valid version in the changelog" time="0.0051" asserts="0" success="True" result="Success" executed="True" />
-                  <test-case description="Changelog and manifest versions are the same" name="Module manifest.Validation.Changelog and manifest versions are the same" time="0.0045" asserts="0" success="True" result="Success" executed="True" />
+                  <test-case description="Has a valid manifest" name="Module manifest.Validation.Has a valid manifest" time="0.0242" asserts="0" success="True" result="Success" executed="True" />
+                  <test-case description="Has a valid name in the manifest" name="Module manifest.Validation.Has a valid name in the manifest" time="0.0406" asserts="0" success="True" result="Success" executed="True" />
+                  <test-case description="Has a valid root module" name="Module manifest.Validation.Has a valid root module" time="0.0196" asserts="0" success="True" result="Success" executed="True" />
+                  <test-case description="Has a valid version in the manifest" name="Module manifest.Validation.Has a valid version in the manifest" time="0.0198" asserts="0" success="True" result="Success" executed="True" />
+                  <test-case description="Has a valid description" name="Module manifest.Validation.Has a valid description" time="0.0222" asserts="0" success="True" result="Success" executed="True" />
+                  <test-case description="Has a valid author" name="Module manifest.Validation.Has a valid author" time="0.0146" asserts="0" success="True" result="Success" executed="True" />
+                  <test-case description="Has a valid guid" name="Module manifest.Validation.Has a valid guid" time="0.0379" asserts="0" success="True" result="Success" executed="True" />
+                  <test-case description="Has a valid copyright" name="Module manifest.Validation.Has a valid copyright" time="0.016" asserts="0" success="True" result="Success" executed="True" />
+                  <test-case description="Has a valid version in the changelog" name="Module manifest.Validation.Has a valid version in the changelog" time="0.0197" asserts="0" success="True" result="Success" executed="True" />
+                  <test-case description="Changelog and manifest versions are the same" name="Module manifest.Validation.Changelog and manifest versions are the same" time="0.018" asserts="0" success="True" result="Success" executed="True" />
                 </results>
               </test-suite>
             </results>
           </test-suite>
-          <test-suite type="TestFixture" name="Git tagging" executed="True" result="Ignored" success="True" time="0.0958" asserts="0" description="Git tagging">
+          <test-suite type="TestFixture" name="Git tagging" executed="True" result="Ignored" success="True" time="0.2694" asserts="0" description="Git tagging">
             <results>
-              <test-case description="Is tagged with a valid version" name="Git tagging.Is tagged with a valid version" time="0.0064" asserts="0" success="False" result="Ignored" executed="False" />
-              <test-case description="Matches manifest version" name="Git tagging.Matches manifest version" time="0.004" asserts="0" success="False" result="Ignored" executed="False" />
+              <test-case description="Is tagged with a valid version" name="Git tagging.Is tagged with a valid version" time="0.0102" asserts="0" success="False" result="Ignored" executed="False" />
+              <test-case description="Matches manifest version" name="Git tagging.Matches manifest version" time="0.0107" asserts="0" success="False" result="Ignored" executed="False" />
             </results>
           </test-suite>
         </results>
       </test-suite>
-      <test-suite type="TestFixture" name="C:\Users\jh\source\repos\WrikeExplorer\tests\Meta.tests.ps1" executed="True" result="Success" success="True" time="0.2445" asserts="0" description="C:\Users\jh\source\repos\WrikeExplorer\tests\Meta.tests.ps1">
+      <test-suite type="TestFixture" name="C:\Users\jh\source\repos\WrikeExplorer\tests\Meta.tests.ps1" executed="True" result="Success" success="True" time="0.4293" asserts="0" description="C:\Users\jh\source\repos\WrikeExplorer\tests\Meta.tests.ps1">
         <results>
-          <test-suite type="TestFixture" name="Text files formatting" executed="True" result="Success" success="True" time="0.0357" asserts="0" description="Text files formatting">
+          <test-suite type="TestFixture" name="Text files formatting" executed="True" result="Success" success="True" time="0.0625" asserts="0" description="Text files formatting">
             <results>
-              <test-suite type="TestFixture" name="Text files formatting.File encoding" executed="True" result="Success" success="True" time="0.0202" asserts="0" description="Text files formatting.File encoding">
+              <test-suite type="TestFixture" name="Text files formatting.File encoding" executed="True" result="Success" success="True" time="0.037" asserts="0" description="Text files formatting.File encoding">
                 <results>
-                  <test-case description="No text file uses Unicode/UTF-16 encoding" name="Text files formatting.File encoding.No text file uses Unicode/UTF-16 encoding" time="0.0154" asserts="0" success="True" result="Success" executed="True" />
+                  <test-case description="No text file uses Unicode/UTF-16 encoding" name="Text files formatting.File encoding.No text file uses Unicode/UTF-16 encoding" time="0.0299" asserts="0" success="True" result="Success" executed="True" />
                 </results>
               </test-suite>
-              <test-suite type="TestFixture" name="Text files formatting.Indentations" executed="True" result="Success" success="True" time="0.0308" asserts="0" description="Text files formatting.Indentations">
+              <test-suite type="TestFixture" name="Text files formatting.Indentations" executed="True" result="Success" success="True" time="0.0581" asserts="0" description="Text files formatting.Indentations">
                 <results>
-                  <test-case description="No text file use tabs for indentations" name="Text files formatting.Indentations.No text file use tabs for indentations" time="0.0059" asserts="0" success="True" result="Success" executed="True" />
+                  <test-case description="No text file use tabs for indentations" name="Text files formatting.Indentations.No text file use tabs for indentations" time="0.0171" asserts="0" success="True" result="Success" executed="True" />
                 </results>
               </test-suite>
             </results>
           </test-suite>
         </results>
       </test-suite>
-      <test-suite type="TestFixture" name="C:\Users\jh\source\repos\WrikeExplorer\tests\WrikeExplorer.tests.ps1" executed="True" result="Success" success="True" time="0.5419" asserts="0" description="C:\Users\jh\source\repos\WrikeExplorer\tests\WrikeExplorer.tests.ps1">
+      <test-suite type="TestFixture" name="C:\Users\jh\source\repos\WrikeExplorer\tests\WrikeExplorer.tests.ps1" executed="True" result="Success" success="True" time="0.825" asserts="0" description="C:\Users\jh\source\repos\WrikeExplorer\tests\WrikeExplorer.tests.ps1">
         <results>
-          <test-suite type="TestFixture" name="Wrike API Success Tests" executed="True" result="Success" success="True" time="0.3096" asserts="0" description="Wrike API Success Tests">
+          <test-suite type="TestFixture" name="Wrike API Success Tests" executed="True" result="Success" success="True" time="0.4951" asserts="0" description="Wrike API Success Tests">
             <results>
-              <test-case description="Get-WrikeContact returns self" name="Wrike API Success Tests.Get-WrikeContact returns self" time="0.3017" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Get-WrikeContact returns self" name="Wrike API Success Tests.Get-WrikeContact returns self" time="0.4802" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
-          <test-suite type="TestFixture" name="Wrike API Error Tests" executed="True" result="Success" success="True" time="0.4895" asserts="0" description="Wrike API Error Tests">
+          <test-suite type="TestFixture" name="Wrike API Error Tests" executed="True" result="Success" success="True" time="0.731" asserts="0" description="Wrike API Error Tests">
             <results>
-              <test-case description="Responds to invalid tokens correctly" name="Wrike API Error Tests.Responds to invalid tokens correctly" time="0.1755" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="Responds to invalid tokens correctly" name="Wrike API Error Tests.Responds to invalid tokens correctly" time="0.2296" asserts="0" success="True" result="Success" executed="True" />
             </results>
           </test-suite>
         </results>


### PR DESCRIPTION
All records with an Id call the field "Id", so for consistency between functions and to ensure `ValueFromPipelineByPropertyName` works without unnecessary alias's, I'll exclusively use Id for any function that accepts one. This is a breaking change, but the module only has a couple downloads and I think they're both me.